### PR TITLE
Fix continent with max death count query

### DIFF
--- a/COVID Portfolio Project - Data Exploration.sql
+++ b/COVID Portfolio Project - Data Exploration.sql
@@ -62,7 +62,7 @@ order by TotalDeathCount desc
 
 -- Showing contintents with the highest death count per population
 
-Select continent, MAX(cast(Total_deaths as int)) as TotalDeathCount
+Select continent, SUM(cast(new_deaths as int)) as TotalDeathCount
 From PortfolioProject..CovidDeaths
 --Where location like '%states%'
 Where continent is not null 


### PR DESCRIPTION
For continent with highest death count ,the query was incorrectly showing the death count for the country which has maximum death in that continent. This PR fixes the query to show the continent with maximum death. Death in each continent is calculated by summing the new deaths for each day.